### PR TITLE
Add User Agent, use new URL

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -64,7 +64,11 @@ var (
 
 // Update function fetches new data from origin API and updates internal cache
 func (c *Cache) Update() {
-	resp, err := http.Get("https://wiimmfi.de/mkw")
+
+	req, err := http.NewRequest("GET", "https://wiimmfi.de/stats/mkw", nil); 
+	req.Header.Add("User-Agent", "Unofficial Wiimmfi API by y21 - github.com/y21/wiimmfi-api")
+	cl := &http.Client{}
+	resp, err := cl.Do(req)
 	if err != nil {
 		fmt.Printf("error while requesting wiimmfi.de/mkw: %v", err)
 		return


### PR DESCRIPTION
Yesterday we moved the /mkw page to /stats/mkw, the old page only shows a redirect. 
Also, I've added a proper User Agent so when we check the logs we know how to contact the owner if it happens to do something weird. 